### PR TITLE
Allow an output filename to be passed to Diagram explicitly.

### DIFF
--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -77,6 +77,7 @@ class Diagram:
     def __init__(
         self,
         name: str = "",
+        filename: str = "",
         direction: str = "LR",
         outformat: str = "png",
         show: bool = True,
@@ -86,7 +87,10 @@ class Diagram:
     ):
         """Diagram represents a global diagrams context.
 
-        :param name: Diagram name. It will be used for output filename.
+        :param name: Diagram name. It will be used for output filename if the
+            filename isn't given.
+        :param filename: The output filename, without the extension (.png).
+            If not given, it will be generated from the name.
         :param direction: Data flow direction. Default is 'left to right'.
         :param outformat: Output file format. Default is 'png'.
         :param show: Open generated image after save if true, just only save otherwise.
@@ -96,7 +100,9 @@ class Diagram:
         """
         self.name = name
 
-        self.filename = "_".join(self.name.split()).lower()
+        if not filename:
+            filename = "_".join(self.name.split()).lower()
+        self.filename = filename
         self.dot = Digraph(self.name, filename=self.filename)
 
         # Set attributes.

--- a/docs/guides/diagram.md
+++ b/docs/guides/diagram.md
@@ -41,6 +41,16 @@ with Diagram("Simple Diagram", outformat="jpg"):
     EC2("web")
 ```
 
+You can specify the output filename with `filename` parameter. The extension shouldn't be included, it's determined by the `outformat` parameter.
+
+```python
+from diagrams import Diagram
+from diagrams.aws.compute import EC2
+
+with Diagram("Simple Diagram", filename="my_diagram"):
+    EC2("web")
+```
+
 You can also disable the automatic file opening by setting the `show` parameter as **false**. Default is **true**.
 
 ```python

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -73,6 +73,18 @@ class DiagramTest(unittest.TestCase):
             self.assertEqual(nodes >> node1, node1)
             self.assertEqual(nodes << node1, node1)
 
+    def test_default_filename(self):
+        self.name = "example_1"
+        with Diagram(name="Example 1", show=False):
+            Node("node1")
+        self.assertTrue(os.path.exists(f"{self.name}.png"))
+
+    def test_custom_filename(self):
+        self.name = "my_custom_name"
+        with Diagram(name="Example 1", filename=self.name, show=False):
+            Node("node1")
+        self.assertTrue(os.path.exists(f"{self.name}.png"))
+
 
 class ClusterTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This allows you to have a consistent output filename, even if you decide
to tweak the diagram name.