### PR TITLE
Add `choco install graphviz` tip for Windows users

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,7 @@ title: Installation
 
 It uses [Graphviz](https://www.graphviz.org/) to render the diagram, so you need to [install Graphviz](https://graphviz.gitlab.io/download/) to use **diagrams**. After installing graphviz (or already have it), install the **diagrams**.
 
-> macOS users can download the Graphviz via `brew install graphviz` if you're using [Homebrew](https://brew.sh).
+> macOS users can download the Graphviz via `brew install graphviz` if you're using [Homebrew](https://brew.sh). Similarly, Windows users with [Chocolatey](https://chocolatey.org) installed can run `choco install graphviz`.
 
 ```shell
 # using pip (pip3)


### PR DESCRIPTION
This PR updates the install docs to provide instructions for streamlined install of the `graphviz` package via [Chocolatey.org](www.chocolatey.org), the Windows package manager which is analogous to Homebrew for Mac.