### PR TITLE
fix: graph_attr example

### DIFF
--- a/docs/guides/diagram.md
+++ b/docs/guides/diagram.md
@@ -83,7 +83,7 @@ from diagrams import Diagram
 from diagrams.aws.compute import EC2
 
 graph_attr = {
-	"fontsize": 45,
+	"fontsize": "45",
 	"bgcolor": "transparent"
 }
 


### PR DESCRIPTION
`graphviz` only support string or byte-like objects as value in attributes. The example was passing `fontsize` as `int` that throws `TypeError`.

Just fixing the example