### PR TITLE
URL, edgeURL, and labelURL support

### DIFF
--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -40,7 +40,7 @@ def setcluster(cluster):
 
 class Diagram:
     __directions = ("TB", "BT", "LR", "RL")
-    __outformats = ("png", "jpg", "svg", "pdf")
+    __outformats = ("png", "jpg", "svg", "pdf", "cmapx")
 
     # fmt: off
     _default_graph_attrs = {
@@ -262,10 +262,11 @@ class Node:
 
     _height = 1.9
 
-    def __init__(self, label: str = ""):
+    def __init__(self, label: str = "", URL: str = ""):
         """Node represents a system component.
 
         :param label: Node label.
+        :param URL: Node URL link. (svg, cmapx only)
         """
         # Generates a hash for identifying a node.
         self._hash = self._rand_hash()
@@ -282,6 +283,9 @@ class Node:
             "image": self._load_icon(),
         } if self._icon else {}
         # fmt: on
+
+        if URL:
+            self.attrs.update({"URL": URL})
 
         # Node must be belong to a diagrams.
         self._diagram = getdiagram()


### PR DESCRIPTION
`edgeURL` and `labelURL` are technically already supported via the `**attrs` Dict in `Edge`'s initializer.

I added a named parameter to `Node` to accept [`URL`](https://www.graphviz.org/doc/info/attrs.html#a:URL).

SVG output natively supports links in the diagram. Links can also be added to jpg and png using `cmapx` which I added to the output types.

To use cmapx you will need to run the diagram generation twice. Once for the png and once for the cmapx file.

I had originally detected if a url was added to a node, edge, or label and autogenerated the cmapx file. I can add that back in if interested, but it seemed to break the paradigm of generating _one file_ from a diagram.

Closes #97 