### PR TITLE
Add command line support using scripts/generate.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,6 @@ isort = "^4.3"
 
 [tool.black]
 line-length = 120
+
+[tool.poetry.scripts]
+diagrams = 'scripts.generate:main'

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -94,9 +94,11 @@ def generate(pvd: str) -> None:
     apidoc = gen_apidoc(pvd, typ_paths)
     make_apidoc(pvd, apidoc)
 
-
-if __name__ == "__main__":
+def main():
     pvd = sys.argv[1]
     if pvd not in cfg.PROVIDERS:
         sys.exit()
     generate(pvd)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Ship a poetry script (package-exported executable command) from the
scripts/generate.py file.

Refactor the main into a function for entrypoint purposes.

Ref #131 


