### PR TITLE
Added option to preserve dot file

### DIFF
--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -83,7 +83,7 @@ class Diagram:
         graph_attr: dict = {},
         node_attr: dict = {},
         edge_attr: dict = {},
-        preserve_graphviz_file=False
+        preserve_graphviz_file: bool = False
     ):
         """Diagram represents a global diagrams context.
 
@@ -128,6 +128,7 @@ class Diagram:
         self.dot.edge_attr.update(edge_attr)
 
         self.show = show
+        self.preserve_graphviz_file = preserve_graphviz_file
 
     def __str__(self) -> str:
         return str(self.dot)

--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -83,6 +83,7 @@ class Diagram:
         graph_attr: dict = {},
         node_attr: dict = {},
         edge_attr: dict = {},
+        preserve_graphviz_file=false
     ):
         """Diagram represents a global diagrams context.
 
@@ -138,7 +139,8 @@ class Diagram:
     def __exit__(self, exc_type, exc_value, traceback):
         self.render()
         # Remove the graphviz file leaving only the image.
-        os.remove(self.filename)
+        if (not self.preserve_graphviz_file):
+            os.remove(self.filename)
         setdiagram(None)
 
     def _repr_png_(self):
@@ -487,7 +489,8 @@ class Edge:
                 self._attrs = o.attrs.copy()
                 result.append(o)
             else:
-                result.append(Edge(o, forward=forward, reverse=reverse, **self._attrs))
+                result.append(
+                    Edge(o, forward=forward, reverse=reverse, **self._attrs))
         return result
 
     def connect(self, other: Union["Node", "Edge", List["Node"]]):

--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -83,7 +83,7 @@ class Diagram:
         graph_attr: dict = {},
         node_attr: dict = {},
         edge_attr: dict = {},
-        preserve_graphviz_file=false
+        preserve_graphviz_file=False
     ):
         """Diagram represents a global diagrams context.
 


### PR DESCRIPTION
```
Diagram("Label", outformat="png", preserve_graphviz_file=True)
```
will preserve the dot file generated for later use.

I could also refactor this so that dot file is preserved when `outformat="dot"`

This is a non-breaking change because `preserve_graphviz_file` is False by default.