### PR TITLE
fix(diagrams): Set a dummy filename to prevent raise error when both …

### DIFF
--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -102,7 +102,7 @@ class Diagram:
         """
         self.name = name
         if not name and not filename:
-          filename = "diagrams_file"
+          filename = "diagrams_image"
         elif not filename:
             filename = "_".join(self.name.split()).lower()
         self.filename = filename

--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -101,8 +101,9 @@ class Diagram:
         :param edge_attr: Provide edge_attr dot config attributes.
         """
         self.name = name
-
-        if not filename:
+        if not name and not filename:
+          filename = "diagrams_file"
+        elif not filename:
             filename = "_".join(self.name.split()).lower()
         self.filename = filename
         self.dot = Digraph(self.name, filename=self.filename)

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -101,11 +101,11 @@ class DiagramTest(unittest.TestCase):
         self.assertTrue(os.path.exists(f"{self.name}.png"))
 
     def test_empty_name(self):
-      """Check that providing an empty name don't crash, but save in a diagrams_file.xxx file."""
-      self.name = 'diagrams_file'
+      """Check that providing an empty name don't crash, but save in a diagrams_image.xxx file."""
+      self.name = 'diagrams_image'
       with Diagram(show=False):
           Node("node1")
-      self.assertTrue(os.path.exists(f"diagrams_file.png"))
+      self.assertTrue(os.path.exists(f"{self.name}.png"))
 
 
 class ClusterTest(unittest.TestCase):

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -100,6 +100,13 @@ class DiagramTest(unittest.TestCase):
             Node("node1")
         self.assertTrue(os.path.exists(f"{self.name}.png"))
 
+    def test_empty_name(self):
+      """Check that providing an empty name don't crash, but save in a diagrams_file.xxx file."""
+      self.name = 'diagrams_file'
+      with Diagram(show=False):
+          Node("node1")
+      self.assertTrue(os.path.exists(f"diagrams_file.png"))
+
 
 class ClusterTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
…name and filename are not provided(#203)

I added a unit test and linked to the issue it may be more clear than a long description.

Why I did it this way: I think that it's more simple (for usage and human users) to just generate a file with a dummy name than raising an error, as it can generate frustration as people may just open an issue and complain that it's not working.