### PR TITLE
feat(docker): Add support for CJK fonts + Replace ms-fonts with opens…

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -3,15 +3,17 @@ FROM python:rc-alpine3.12
 
 # install system dependencies.
 RUN apk update && apk add --no-cache \
-  gcc libc-dev g++ graphviz git bash go imagemagick inkscape
+  gcc libc-dev g++ graphviz git bash go imagemagick inkscape ttf-opensans curl fontconfig
 
 # install go package.
 RUN go get github.com/mingrammer/round
 
 # install fonts
-RUN apk --no-cache add msttcorefonts-installer fontconfig && \
-    update-ms-fonts && \
-    fc-cache -f
+RUN curl -O https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip \
+&& mkdir -p /usr/share/fonts/NotoSansCJKjp \
+&& unzip NotoSansCJKjp-hinted.zip -d /usr/share/fonts/NotoSansCJKjp/ \
+&& rm NotoSansCJKjp-hinted.zip \
+&& fc-cache -fv
 
 # add go bin to path.
 ENV PATH "$PATH:/root/go/bin"


### PR DESCRIPTION
…ans.

There's 2 changes in one push:

1- Added support for CJK fonts as with the actual version the CJK was displayed as square (see the second screenshot).
2- Replaced ms-font with opensans as opensans fonts are already in the official repository and for sure will have better support.

As you can see in the diagrams generated the text is sometimes going outside of the bound with ms-fonts, the version with opensans is more clean.

With opensans 
![testfontsCJKOpenSans](https://user-images.githubusercontent.com/283765/88267982-a0d77d80-cd0c-11ea-883a-d81787644258.png)

With ms-font
![testfontsMSfont](https://user-images.githubusercontent.com/283765/88267984-a208aa80-cd0c-11ea-9d92-a0e8d1947bec.png)
