### PR TITLE
add Outscale __init__.py

### DIFF
--- a/diagrams/outscale/__init__.py
+++ b/diagrams/outscale/__init__.py
@@ -1,0 +1,8 @@
+from diagrams import Node
+
+
+class _Outscale(Node):
+    _provider = "outscale"
+    _icon_dir = "resources/outscale"
+
+    fontcolor = "#ffffff"


### PR DESCRIPTION
So I've test the code on my Machine and it seems I've forgot to add the __init__.py

Sorry about the inconvenience.

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>