### PR TITLE
docs(website): update Fluentd path in examples

### DIFF
--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -178,7 +178,7 @@ from diagrams.onprem.analytics import Spark
 from diagrams.onprem.compute import Server
 from diagrams.onprem.database import PostgreSQL
 from diagrams.onprem.inmemory import Redis
-from diagrams.onprem.logging import Fluentd
+from diagrams.onprem.aggregator import Fluentd
 from diagrams.onprem.monitoring import Grafana, Prometheus
 from diagrams.onprem.network import Nginx
 from diagrams.onprem.queue import Kafka
@@ -221,7 +221,7 @@ from diagrams.onprem.analytics import Spark
 from diagrams.onprem.compute import Server
 from diagrams.onprem.database import PostgreSQL
 from diagrams.onprem.inmemory import Redis
-from diagrams.onprem.logging import Fluentd
+from diagrams.onprem.aggregator import Fluentd
 from diagrams.onprem.monitoring import Grafana, Prometheus
 from diagrams.onprem.network import Nginx
 from diagrams.onprem.queue import Kafka


### PR DESCRIPTION
Fluentd was moved from logging to aggregator in the following PR: 

https://github.com/mingrammer/diagrams/pull/295

but the examples was not updated, this PR update the path in the examples.