### PR TITLE
[Docker] Update to use latest stable python 3

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,9 +1,9 @@
-# use latest python alphine image.
-FROM python:rc-alpine3.12
+# use latest python 3 alpine image.
+FROM python:3-alpine
 
 # install system dependencies.
 RUN apk update && apk add --no-cache \
-  gcc libc-dev g++ graphviz git bash go imagemagick inkscape ttf-opensans curl fontconfig
+  gcc libc-dev g++ graphviz git bash go imagemagick inkscape ttf-opensans curl fontconfig xdg-utils
 
 # install go package.
 RUN go get github.com/mingrammer/round


### PR DESCRIPTION
Updated the docker alpine image as it was previously using rc which is actually using python 3.10.0a5... which was raising several errors, I think it's better to stay on stable version to ensure that all the other dependencies are able to run.

Detail of the python version (It may change when you will check as the rc is always on the latest python version).
https://hub.docker.com/_/python/

I go with python:3-alpine which is now (when I write the PR) on 3.9.2.

I also added xgd-utils to solve warning.