### PR TITLE
fix(website): add IBM in the side menu

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -15,6 +15,7 @@
       "nodes/aws",
       "nodes/azure",
       "nodes/gcp",
+      "nodes/ibm",
       "nodes/k8s",
       "nodes/alibabacloud",
       "nodes/oci",


### PR DESCRIPTION
As written in the title added IBM link in the side bar for the docs.