### PR TITLE
Add Python 3.9 to badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](/LICENSE)
 [![pypi version](https://badge.fury.io/py/diagrams.svg)](https://badge.fury.io/py/diagrams)
-![python version](https://img.shields.io/badge/python-3.6%2C3.7%2C3.8-blue?logo=python)
+![python version](https://img.shields.io/badge/python-3.6%2C3.7%2C3.8%2C3.9-blue?logo=python)
 ![Run tests](https://github.com/mingrammer/diagrams/workflows/Run%20tests/badge.svg?branch=master)
 [![todos](https://badgen.net/https/api.tickgit.com/badgen/github.com/mingrammer/diagrams?label=todos)](https://www.tickgit.com/browse?repo=github.com/mingrammer/diagrams)
 ![contributors](https://img.shields.io/github/contributors/mingrammer/diagrams)


### PR DESCRIPTION
Add Python 3.9 to badges ai this is a tested version in CI.

Other ideas maybe is to use `3.6+` or `^3.6`

![python version](https://img.shields.io/badge/python-3.6%2B-blue?logo=python)

![python version](https://img.shields.io/badge/python-%5E3.6-blue?logo=python)
