### PR TITLE
Prefer subprocess run over call

### DIFF
--- a/scripts/resource.py
+++ b/scripts/resource.py
@@ -165,7 +165,7 @@ def round_png(pvd: str) -> None:
 
     def _round(base: str, path: str):
         path = os.path.join(base, path)
-        subprocess.call([cfg.CMD_ROUND, *cfg.CMD_ROUND_OPTS, path])
+        subprocess.run([cfg.CMD_ROUND, *cfg.CMD_ROUND_OPTS, path])
 
     for root, _, files in os.walk(resource_dir(pvd)):
         pngs = filter(lambda f: f.endswith(".png"), files)
@@ -178,8 +178,8 @@ def svg2png(pvd: str) -> None:
 
     def _convert(base: str, path: str):
         path = os.path.join(base, path)
-        subprocess.call([cfg.CMD_SVG2PNG, *cfg.CMD_SVG2PNG_OPTS, path])
-        subprocess.call(["rm", path])
+        subprocess.run([cfg.CMD_SVG2PNG, *cfg.CMD_SVG2PNG_OPTS, path])
+        subprocess.run(["rm", path])
 
     for root, _, files in os.walk(resource_dir(pvd)):
         svgs = filter(lambda f: f.endswith(".svg"), files)
@@ -192,8 +192,8 @@ def svg2png2(pvd: str) -> None:
     def _convert(base: str, path: str):
         path_src = os.path.join(base, path)
         path_dest = path_src.replace(".svg", ".png")
-        subprocess.call([cfg.CMD_SVG2PNG_IM, *cfg.CMD_SVG2PNG_IM_OPTS, path_src, path_dest])
-        subprocess.call(["rm", path_src])
+        subprocess.run([cfg.CMD_SVG2PNG_IM, *cfg.CMD_SVG2PNG_IM_OPTS, path_src, path_dest])
+        subprocess.run(["rm", path_src])
 
     for root, _, files in os.walk(resource_dir(pvd)):
         svgs = filter(lambda f: f.endswith(".svg"), files)


### PR DESCRIPTION
1. Fix resource warning in the destructor
```
/Users/REDACTED/.asdf/installs/python/3.10.0/lib/python3.10/subprocess.py:1067: ResourceWarning: subprocess 46612 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback

```

2. Use preferred, non-legacy API per https://docs.python.org/3/library/subprocess.html#subprocess.call
3. Older call style no longer needed with Python 3.6+