### PR TITLE
Fix For go get Deprecation

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -6,7 +6,7 @@ RUN apk update && apk add --no-cache \
   gcc libc-dev g++ graphviz git bash go imagemagick inkscape ttf-opensans curl fontconfig xdg-utils
 
 # install go package.
-RUN go get github.com/mingrammer/round
+RUN go install github.com/mingrammer/round@latest
 
 # install fonts
 RUN curl -O https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip \


### PR DESCRIPTION
**Summary**

Docker fails to build due to `go get` deprecation.  This change addresses the deprecation and allows for a successful build by replacing `go get` with `go install somePackage/package@version.`

**Testing**

Successfully built the docker image on amd64 Ubuntu and arm64 M1 Mac.