### PR TITLE
Load icon image based on class name

### DIFF
--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -1,5 +1,6 @@
 import contextvars
 import os
+import re
 import uuid
 from pathlib import Path
 from typing import List, Union, Dict
@@ -279,6 +280,7 @@ class Node:
 
     _icon_dir = None
     _icon = None
+    _icon_ext = ".png"
 
     _height = 1.9
 
@@ -394,7 +396,15 @@ class Node:
             else:
                 o.connect(self, Edge(self, reverse=True))
         return self
-
+    
+    def _get_icon(self):
+        if self._icon:
+            return self._icon
+        
+        icon = re.sub(r'(?<!^)(?=[A-Z])', '-', self.__class__.__name__).lower()
+        
+        return f'{icon}.{self._icon_ext}'
+    
     @property
     def nodeid(self):
         return self._id
@@ -421,7 +431,7 @@ class Node:
 
     def _load_icon(self):
         basedir = Path(os.path.abspath(os.path.dirname(__file__)))
-        return os.path.join(basedir.parent, self._icon_dir, self._icon)
+        return os.path.join(basedir.parent, self._icon_dir, self._get_icon())
 
 
 class Edge:


### PR DESCRIPTION
Auto load icon images based on `Node` class name converted to *kabob-case*.
Icon's filenames will be appended the `.png` extension by default, but can be overwritten by assigning a value to `_icon_ext`.

The current functionality remains compatible, but this will allow the following convention:
- Assuming the node class is named `GithubActions` ➡️ `"github-actions.png"` will be assumed.

The [*regex*](https://github.com/mingrammer/diagrams/pull/776/files#diff-6d8e3d749d7b887abdbe01f7d7ce3129d7230ce9ea42bd05684f064a2ae07ed7R404) being used can be compiled and saved at the *class* level for performance.