### PR TITLE
fix: Syntax error in config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ DIR_TEMPLATE = "templates"
 
 PROVIDERS = (
     "base",
-    "onprem"
+    "onprem",
     "aws",
     "azure",
     "digitalocean",


### PR DESCRIPTION
The PROVIDERS constant in config.py was missing a comma in the list which was causing autogeneration to fail. Found this while trying to add a new icon to onprem.

I expect this is going to cause a few updates.