### PR TITLE
fix(tests): set lower for case sensitive system

### DIFF
--- a/tests/test_c4.py
+++ b/tests/test_c4.py
@@ -10,7 +10,7 @@ from diagrams.c4 import Person, Container, Database, System, SystemBoundary, Rel
 
 class C4Test(unittest.TestCase):
     def setUp(self):
-        self.name = "diagram-" + "".join([random.choice(string.hexdigits) for n in range(7)])
+        self.name = "diagram-" + "".join([random.choice(string.hexdigits) for n in range(7)]).lower()
 
     def tearDown(self):
         setdiagram(None)


### PR DESCRIPTION
When running tests for c4 the setUp() initialize a name variable that is used as name parameter for Diagram() class.
The name variable generated have upper case. ex: "diagram-e1Ad2eF"

In Diagram class when name parameter is provided it's used to generate a file in lower case.
filename = "_".join(self.name.split()).lower()
So when the tearDown is called and ask to remove the file using self.name with upper case, the file are not found so not removed.
os.remove(self.name + ".png")

It may work in windows as windows is case insensitive but not for linux.