### PR TITLE
Delete Gitpitch from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ To contribute to diagram, check out [contribution guidelines](CONTRIBUTING.md).
 
 ## Who uses it?
 
-[GitPitch](https://gitpitch.github.io/gitpitch) is the perfect slide deck solution for Tech Conferences, Training, Developer Advocates, and Educators. Diagrams is now available as a dedicated [Cloud Diagram Markdown Widget](https://gitpitch.github.io/gitpitch/#/diagrams/cloud-architecture) so you can use Diagrams directly on any slide for conferences, meetups, and training.
-
 [Cloudiscovery](https://github.com/Cloud-Architects/cloudiscovery) helps you to analyze resources in your cloud (AWS/GCP/Azure/Alibaba/IBM) account. It allows you to create a diagram of analyzed cloud resource map based on this Diagrams library, so you can draw your existing cloud infrastructure with Cloudiscovery.
 
 [Airflow Diagrams](https://github.com/feluelle/airflow-diagrams) is an Airflow plugin that aims to easily visualise your Airflow DAGs on service level from providers like AWS, GCP, Azure, etc. via diagrams.


### PR DESCRIPTION
https://gitpitch.github.io/gitpitch/#/free-trial
```
GitPitch is shutting down on March 1, 2021. The trial software is no longer available for download.
````