### PR TITLE
Fix `Edge.append` method

### DIFF
--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -517,7 +517,7 @@ class Edge:
         for o in other:
             if isinstance(o, Edge):
                 o.forward = forward if forward else o.forward
-                o.reverse = forward if forward else o.reverse
+                o.reverse = reverse if reverse else o.reverse
                 self._attrs = o.attrs.copy()
                 result.append(o)
             else:


### PR DESCRIPTION
The `reverse` property was set incorrectly because it wasn't taken into account (`forward` argument was used)