### PR TITLE
Fix parameter type of outformat

### DIFF
--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -82,7 +82,7 @@ class Diagram:
         filename: str = "",
         direction: str = "LR",
         curvestyle: str = "ortho",
-        outformat: str = "png",
+        outformat: str | list[str] = "png",
         autolabel: bool = False,
         show: bool = True,
         strict: bool = False,


### PR DESCRIPTION
According to the implementation of `Diagram.__init__`, `outformat` can be either a `str` or a `list[str]`, but the function parameter type only accepts `str`. This PR fixes this issue.