### PR TITLE
added devcontainer support for vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+# use latest python 3 alpine image.
+FROM python:3-alpine
+
+# install system dependencies.
+RUN apk update && apk add --no-cache \
+  gcc libc-dev g++ graphviz git bash go imagemagick inkscape ttf-opensans curl fontconfig xdg-utils
+
+# install go package.
+RUN go install github.com/mingrammer/round@latest
+
+# install fonts
+RUN curl -O https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip \
+&& mkdir -p /usr/share/fonts/NotoSansCJKjp \
+&& unzip NotoSansCJKjp-hinted.zip -d /usr/share/fonts/NotoSansCJKjp/ \
+&& rm NotoSansCJKjp-hinted.zip \
+&& fc-cache -fv
+
+# add go bin to path.
+ENV PATH "$PATH:/root/go/bin"
+
+# project directory.
+WORKDIR /usr/src/diagrams
+
+# Copy the rest of your app's source code from your host to your image filesystem.
+COPY . .
+
+# install python requirements.
+RUN pip install black graphviz jinja2

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3-alpine
 
 # install system dependencies.
 RUN apk update && apk add --no-cache \
-  gcc libc-dev g++ graphviz git bash go imagemagick inkscape ttf-opensans curl fontconfig xdg-utils
+  gcc libc-dev g++ graphviz git bash go imagemagick inkscape ttf-opensans curl fontconfig xdg-utils \
+  nodejs npm
 
 # install go package.
 RUN go install github.com/mingrammer/round@latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+	"name": "diagrams",
+    "build": {
+        // Path is relative to the devcontainer.json file.
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.debugpy",
+				"mhutchie.git-graph",			
+				"mutantdino.resourcemonitor",
+				"tehpeng.diagramspreviewer"
+			]
+		}
+	},
+	"workspaceMount": "source=${localWorkspaceFolder},target=/usr/src/diagrams,type=bind",
+	"workspaceFolder": "/usr/src/diagrams"
+}


### PR DESCRIPTION
Added [Dev Container](https://containers.dev/) support to automate the lifecycle of local development setup using [VSCode and containers](https://code.visualstudio.com/docs/devcontainers/containers). Based on the existing Dockerfile (copied under the new `.devcontainer` folder) the following VSCode extensions were added:

- Python, Python Debugger, Pylance (Microsoft extensions)
- Git Graph (mhutchie.git-graph)
- Resource Monitor (mutantdino.resourcemonitor)
- Diagrams Previewer (tehpeng.diagramspreviewer)

The new `.devcontainer/Dockerfile` additionally installs the following packages in base image:

- nodejs
- npm

!! The `docker/dev/Dockerfile` is no longer needed **but it's been left intact**. !!
