### PR TITLE
Add "save_to_disk" flag in the Diagram class to control automatic diagram file saving

### DIFF
--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -89,6 +89,7 @@ class Diagram:
         graph_attr: Optional[dict] = None,
         node_attr: Optional[dict] = None,
         edge_attr: Optional[dict] = None,
+        save_to_disk: bool = True,  # Add flag to control saving behavior
     ):
         """Diagram represents a global diagrams context.
 
@@ -118,6 +119,9 @@ class Diagram:
             filename = "_".join(self.name.split()).lower()
         self.filename = filename
         self.dot = Digraph(self.name, filename=self.filename, strict=strict)
+        if save_to_disk is None:
+            save_to_disk = True
+
 
         # Set attributes.
         for k, v in self._default_graph_attrs.items():
@@ -152,6 +156,7 @@ class Diagram:
 
         self.show = show
         self.autolabel = autolabel
+        self.save_to_disk = save_to_disk
 
     def __str__(self) -> str:
         return str(self.dot)
@@ -161,10 +166,12 @@ class Diagram:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.render()
-        # Remove the graphviz file leaving only the image.
-        os.remove(self.filename)
+        if self.save_to_disk:  # Only render if save_to_disk is True
+            self.render()
+            # Remove the graphviz file leaving only the image.
+            os.remove(self.filename)
         setdiagram(None)
+
 
     def _repr_png_(self):
         return self.dot.pipe(format="png")
@@ -191,11 +198,12 @@ class Diagram:
         self.dot.subgraph(dot)
 
     def render(self) -> None:
-        if isinstance(self.outformat, list):
-            for one_format in self.outformat:
-                self.dot.render(format=one_format, view=self.show, quiet=True)
-        else:
-            self.dot.render(format=self.outformat, view=self.show, quiet=True)
+        if self.save_to_disk:  # Only save if save_to_disk is True
+            if isinstance(self.outformat, list):
+                for one_format in self.outformat:
+                    self.dot.render(format=one_format, view=self.show, quiet=True)
+            else:
+                self.dot.render(format=self.outformat, view=self.show, quiet=True)
 
 
 class Cluster:


### PR DESCRIPTION
This pull request introduces a new feature to the Diagram class: the save_to_disk flag. This flag allows users to control whether the generated diagram should be saved to disk or not. By default, the diagram is still saved to disk, which preserves the current behavior. However, by setting save_to_disk=False, users can prevent the diagram from being written to a file.

Key Amendments:
save_to_disk Flag:

Added a new optional parameter save_to_disk to the Diagram class constructor (__init__ method).
The save_to_disk flag controls whether the diagram is saved to disk. If set to False, the diagram will not be saved as a file.

Modified the Diagram class render() method
The render() method now checks the value of save_to_disk before saving the diagram. If save_to_disk is False, the diagram rendering process will be skipped, and the diagram will not be saved to disk.

Modified the exit() method
The __exit__() method, which is called when exiting the with Diagram(...) context, now checks the save_to_disk flag. If save_to_disk is True, the diagram is rendered and saved as usual. If save_to_disk is False, the rendering is skipped.

Why These Changes Are Needed:
Currently, the Diagram class always saves the generated diagram to disk and users do not have the option to easily disable this. This behavior can be unnecessary or undesirable in situations where users only need to work with the diagram in memory in a byte stream (e.g., for further processing, testing, or streaming). The addition of the save_to_disk flag provides users with more flexibility and control over how their diagrams are handled.