### PR TITLE
fix: keep the backward compatibility for type hint

### DIFF
--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -82,7 +82,7 @@ class Diagram:
         filename: str = "",
         direction: str = "LR",
         curvestyle: str = "ortho",
-        outformat: str | list[str] = "png",
+        outformat: Union[str, list[str]] = "png",
         autolabel: bool = False,
         show: bool = True,
         strict: bool = False,


### PR DESCRIPTION
Hi @liancheng @gabriel-tessier . The `|` for type hint does not work for < Python 3.9. I fixed it with the Union function.