### PR TITLE
Add diagrams-as-code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ To contribute to diagram, check out [contribution guidelines](CONTRIBUTING.md).
 ## Other languages
 
 - If you are familiar with Go, you can use [go-diagrams](https://github.com/blushft/go-diagrams) as well.
+- Or if you prefer Yaml, you can use [diagrams-as-code](https://github.com/dmytrostriletskyi/diagrams-as-code).
 
 ## License
 


### PR DESCRIPTION
Suggestion about adding a project based on diagrams with yaml, last activity is one year ago but maybe not completely dead, it may help to revive it.