### PR TITLE
Remove typed-ast

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ diagrams="diagrams.cli:main"
 python = "^3.9"
 graphviz = ">=0.13.2,<0.21.0"
 jinja2 = ">=2.10,<4.0"
-typed-ast = {version="^1.5.5", markers="python_version<'3.8'"}
 pre-commit = "^4.0.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Marker was for Python < 3.8, only Python > 3.9 is supported nowadays