### PR TITLE
docs: Fix incorrect on-premise refs from PR #1023

### DIFF
--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -211,9 +211,9 @@ with Diagram("Advanced Web Service with On-Premises", show=False):
     ingress >> grpcsvc >> aggregator
 ```
 
-![advanced web service with on-premise diagram](/img/advanced_web_service_with_on-premise.png)
+![advanced web service with on-premises diagram](/img/advanced_web_service_with_on-premises.png)
 
-## Advanced Web Service with On-Premise (with colors and labels)
+## Advanced Web Service with On-Premises (with colors and labels)
 
 ```python
 from diagrams import Cluster, Diagram, Edge
@@ -226,7 +226,7 @@ from diagrams.onprem.monitoring import Grafana, Prometheus
 from diagrams.onprem.network import Nginx
 from diagrams.onprem.queue import Kafka
 
-with Diagram(name="Advanced Web Service with On-Premise (colored)", show=False):
+with Diagram(name="Advanced Web Service with On-Premises (colored)", show=False):
     ingress = Nginx("ingress")
 
     metrics = Prometheus("metric")
@@ -254,7 +254,7 @@ with Diagram(name="Advanced Web Service with On-Premise (colored)", show=False):
     ingress >> Edge(color="darkgreen") << grpcsvc >> Edge(color="darkorange") >> aggregator
 ```
 
-![advanced web service with on-premise diagram colored](/img/advanced_web_service_with_on-premise_colored.png)
+![advanced web service with on-premises diagram colored](/img/advanced_web_service_with_on-premises_colored.png)
 
 ## RabbitMQ Consumers with Custom Nodes
 


### PR DESCRIPTION
#1023 had a small number of mistakes, the most import of which broke the image links on the Examples page for the AWS on-premises examples

This PR corrects the issues and uses on-premises (or one instance of on-premise in the changelog) where needed