### PR TITLE
specify package/include instead of auto-discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,12 @@ authors = ["mingrammer <mingrammer@gmail.com>"]
 readme = "README.md"
 homepage = "https://diagrams.mingrammer.com"
 repository = "https://github.com/mingrammer/diagrams"
-include = ["resources/**/*"]
+packages = [
+    { include = "diagrams", from = "." }
+]
+include = [
+    { path = "resources", format = ["sdist", "wheel"] }
+]
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
Fixes several failure modes related to broken installs and missing icons as documented in issue #1099 