### PR TITLE
fix: remove unimplemented command-line config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,6 @@ homepage = "https://diagrams.mingrammer.com"
 repository = "https://github.com/mingrammer/diagrams"
 include = ["resources/**/*"]
 
-[tool.poetry.scripts]
-diagrams="diagrams.cli:main"
-
 [tool.poetry.dependencies]
 python = "^3.9"
 graphviz = ">=0.13.2,<0.21.0"


### PR DESCRIPTION
We don't have an official CLI. But there was an added line for the command line config by [mistake](https://github.com/mingrammer/diagrams/pull/1050). I removed it.