### PR TITLE
Fix packaging: Ensure resources are included in both sdist and wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["mingrammer <mingrammer@gmail.com>"]
 readme = "README.md"
 homepage = "https://diagrams.mingrammer.com"
 repository = "https://github.com/mingrammer/diagrams"
-include = ["resources/**/*"]
+include = [{ path = "resources/**/*", format = ["sdist", "wheel"] }]
 
 [tool.poetry.scripts]
 diagrams="diagrams.cli:main"


### PR DESCRIPTION
Poetry's `include` directive defaults to only including files in the sdist. See https://github.com/python-poetry/poetry-core/pull/773