### PR TITLE
fix: icon image positioning within node

### DIFF
--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -62,7 +62,7 @@ class Diagram:
         # imagepos attribute is not backward compatible
         # TODO: check graphviz version to see if "imagepos" is available >= 2.40
         # https://github.com/xflr6/graphviz/blob/master/graphviz/backend.py#L248
-        # "imagepos": "tc",
+        "imagepos": "tc",
         "imagescale": "true",
         "fontname": "Sans-Serif",
         "fontsize": "13",

--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -315,13 +315,14 @@ class Node:
                 self.label = prefix
 
         # fmt: off
-        # If a node has an icon, set the imagepos attr so
-        # that that the icon image is top centered.
+        # If a node has an icon, increase the height slightly to avoid
+        # that label being spanned between icon image and white space.
+        # Increase the height by the number of new lines included in the label.
+        padding = 0.4 * (self.label.count('\n'))
         self._attrs = {
             "shape": "none",
-            "height": str(self._height),
+            "height": str(self._height + padding),
             "image": self._load_icon(),
-            "imagepos": "tc",
         } if self._icon else {}
 
         # fmt: on

--- a/diagrams/__init__.py
+++ b/diagrams/__init__.py
@@ -315,14 +315,13 @@ class Node:
                 self.label = prefix
 
         # fmt: off
-        # If a node has an icon, increase the height slightly to avoid
-        # that label being spanned between icon image and white space.
-        # Increase the height by the number of new lines included in the label.
-        padding = 0.4 * (self.label.count('\n'))
+        # If a node has an icon, set the imagepos attr so
+        # that that the icon image is top centered.
         self._attrs = {
             "shape": "none",
-            "height": str(self._height + padding),
+            "height": str(self._height),
             "image": self._load_icon(),
+            "imagepos": "tc",
         } if self._icon else {}
 
         # fmt: on


### PR DESCRIPTION
This fixes a bug where the icon image will sit _within_ the node and not at the bound. This causes an issue where edges are not 'joined' to the icon.

Example:
<img width="1973" height="2166" alt="image" src="https://github.com/user-attachments/assets/57057f59-2ed4-486f-932d-da7deb44858b" />
Edges leaving and joining at the top center (north) position of the node do not visually look to make contact with the icon.

After this change:
<img width="1973" height="1974" alt="image" src="https://github.com/user-attachments/assets/5a1d9285-f26c-4561-8bd2-ea9b215ad7ec" />

I believe this is a fix for #967

I note the existing comment about support for the `imagepos` attr needing graphviz > 2.4, however since we're on version 14.x now, I don't see how it's worth having this graphical issue over dropping support for an older version.
