### PR TITLE
Fix typo in docs, in diagram code (Clustered web services)

### DIFF
--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -49,6 +49,7 @@ with Diagram("Clustered Web Services", show=False):
 
     dns >> lb >> svc_group
     svc_group >> db_primary
+    db_primary - db_secondary
     svc_group >> memcached
 ```
 


### PR DESCRIPTION
There is a mismatch between the diagram source code and the diagram png when running the diagram code. It misses a relationship between the two databases.