### PR TITLE
Fix bug in docs (Edges page - basic coloring)

### DIFF
--- a/docs/guides/edge.md
+++ b/docs/guides/edge.md
@@ -65,7 +65,7 @@ with Diagram(name="Advanced Web Service with On-Premises (colored)", show=False)
         >> Edge(color="darkorange") \
         >> aggregator
 ```
-![advanced web service with on-premise diagram colored](/img/advanced_web_service_with_on-premise_colored.png)
+![advanced web service with on-premise diagram colored](/img/advanced_web_service_with_on-premises_colored.png)
 
 ## Less Edges
 


### PR DESCRIPTION
The diagram image doesn't show correctly.
There is a typo in the image URI.
Instead of `/img/advanced_web_service_with_on-premise_colored.png` should be  `/img/advanced_web_service_with_on-premises_colored.png`