### PR TITLE
fix: update broken Noto Sans CJK font download URL in Dockerfiles

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,10 +10,10 @@ RUN apk update && apk add --no-cache \
 RUN go install github.com/mingrammer/round@latest
 
 # install fonts
-RUN curl -O https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip \
+RUN curl -L -O https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/06_NotoSansCJKjp.zip \
 && mkdir -p /usr/share/fonts/NotoSansCJKjp \
-&& unzip NotoSansCJKjp-hinted.zip -d /usr/share/fonts/NotoSansCJKjp/ \
-&& rm NotoSansCJKjp-hinted.zip \
+&& unzip 06_NotoSansCJKjp.zip -d /usr/share/fonts/NotoSansCJKjp/ \
+&& rm 06_NotoSansCJKjp.zip \
 && fc-cache -fv
 
 # add go bin to path.

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -9,10 +9,10 @@ RUN apk update && apk add --no-cache \
 RUN go install github.com/mingrammer/round@latest
 
 # install fonts
-RUN curl -O https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip \
+RUN curl -L -O https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/06_NotoSansCJKjp.zip \
 && mkdir -p /usr/share/fonts/NotoSansCJKjp \
-&& unzip NotoSansCJKjp-hinted.zip -d /usr/share/fonts/NotoSansCJKjp/ \
-&& rm NotoSansCJKjp-hinted.zip \
+&& unzip 06_NotoSansCJKjp.zip -d /usr/share/fonts/NotoSansCJKjp/ \
+&& rm 06_NotoSansCJKjp.zip \
 && fc-cache -fv
 
 # add go bin to path.


### PR DESCRIPTION
Hi😀

When running `docker build --tag diagrams:1.0 -f ./docker/dev/Dockerfile .`, the build fails with the following error.

```
Dockerfile:12
--------------------
  11 |     # install fonts
  12 | >>> RUN curl -O https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip \
  13 | >>> && mkdir -p /usr/share/fonts/NotoSansCJKjp \
  14 | >>> && unzip NotoSansCJKjp-hinted.zip -d /usr/share/fonts/NotoSansCJKjp/ \
  15 | >>> && rm NotoSansCJKjp-hinted.zip \
  16 | >>> && fc-cache -fv
  17 |
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c curl -O https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip && mkdir -p /usr/share/fonts/NotoSansCJKjp && unzip NotoSansCJKjp-hinted.zip -d /usr/share/fonts/NotoSansCJKjp/ && rm NotoSansCJKjp-hinted.zip && fc-cache -fv" did not complete successfully: exit code: 1
```

The Noto Sans CJK font download URL appears to return a 403 response now.
https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip

So I replace the font download URL with the official GitHub release from notofonts/noto-cjk.
https://github.com/notofonts/noto-cjk

Let me know if this approach looks good.
Thanks a lot 👍