### PR TITLE
fix: standardise Azure svg-to-png conversion on rsvg-convert

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3-alpine
 
 # install system dependencies.
 RUN apk update && apk add --no-cache \
-  gcc libc-dev g++ graphviz git bash go imagemagick inkscape ttf-opensans curl fontconfig xdg-utils \
+  gcc libc-dev g++ graphviz git bash go imagemagick rsvg-convert ttf-opensans curl fontconfig xdg-utils \
   nodejs npm
 
 # install go package.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,41 +31,44 @@ ffmpeg -i my_big_image.jpg -vf scale=w=256:h=256:force_original_aspect_ratio=dec
 Then just run the `./autogen.sh` to generate the added or updated node classes. (cf. [DEVELOPMENT][DEVELOPMENT.md])
 
 > IMPORTANT NOTE: To run `autogen.sh`, you need the [round][round], [black][black] and
-> [inkscape][inkscape] command line tools that are used for cleaning the image
+> [rsvg-convert][librsvg] command line tools that are used for cleaning the image
 > resource filenames and formatting the generated python code.
 >
-> macOS users can download inkscape via Homebrew.
+> macOS users can install `rsvg-convert` with `brew install librsvg`.
 >
 > Or you can use the docker image.
 
 [DEVELOPMENT.md]: ./DEVELOPMENT.md
 [round]: https://github.com/mingrammer/round
 [black]: https://pypi.org/project/black
-[inkscape]: https://inkscape.org/ko/release
+[librsvg]: https://gitlab.gnome.org/GNOME/librsvg
 
 #### Update Specific Instructions for Azure Icons
 
-Download and unzip [Azure Icons](https://learn.microsoft.com/en-us/azure/architecture/icons/)
+Download and unzip [Azure Icons](https://learn.microsoft.com/en-us/azure/architecture/icons/).
 
-Execute inside Azure_Public_Service_Icons/Icons/
+The only manual step is renaming the directories that ship with spaces and `+`
+signs in their names, since those become the python module names. Execute inside
+`Azure_Public_Service_Icons/Icons/`:
+
 ```bash
-# Rename some diretories
-mv ai\ +\ machine\ learning/ aimachinelearning/
+mv ai\ +\ machine\ learning/ aimachinelearning
 mv app\ services/ appservices
 mv azure\ stack/ azurestack
 mv azure\ ecosystem/ azureecosystem
 mv management\ +\ governance/ managementgovernance
-mv  mixed\ reality mixedreality
+mv mixed\ reality/ mixedreality
 mv new\ icons/ newicons
-#  Convert Name to name
-rename -f 'y/A-Z/a-z/' ./*/*
-# Create png files and eliminate ?????-icon-service from namefile
-find . -type f -name "*.svg" -exec bash -c 'inkscape -h 256  --export-filename="${0%.svg}.png" "$0";mv "${0%.svg}.png" "$(echo "${0%.svg}.png" | sed -r 's/[0-9]{5}-icon-service-//')"' {} \;
-# Delete svg files
-find . -type f -name "*.svg" -exec bash -c 'rm "$0"' {} \;
 ```
 
-If you get any errors with autogen, it will probably be a '+' in  filename
+Then copy the directories into `resources/azure/` and run `./autogen.sh`. Don't
+convert the SVGs by hand: `autogen.sh` rasterises them with `rsvg-convert` at the
+size configured in [config.py](config.py), lowercases the file names and strips
+the `?????-icon-service-` prefix for you. Converting them yourself with a
+different tool produces byte-different PNGs from identical artwork, which turns
+an icon refresh into hundreds of files that only look changed.
+
+If any file name still trips up autogen, it's most likely a `+` left in it.
 
 ### Add new provider
 
@@ -94,10 +97,10 @@ or update the `ALIASES` map in [config.py](config.py).
 Then just run the `./autogen.sh` to generate the added or updated aliases. (cf. [DEVELOPMENT][DEVELOPMENT.md])
 
 > IMPORTANT NOTE: To run `autogen.sh`, you need the [round][round] and
-> [inkscape][inkscape] command line tools that are used for cleaning the image
+> [rsvg-convert][librsvg] command line tools that are used for cleaning the image
 > resource filenames.
 >
-> macOS users can download inkscape via Homebrew.
+> macOS users can install `rsvg-convert` with `brew install librsvg`.
 >
 > Or you can use the docker image.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -58,7 +58,7 @@ To be able to develop and run diagrams locally on you Mac device, you should hav
 4. Install diagrams binary dependencies.
 
     ```shell
-    brew install imagemagick inkscape black
+    brew install imagemagick librsvg black
     go install github.com/mingrammer/round@latest
     # ln -sf ~/go/bin/round ~/.local/bin/round
     ```

--- a/autogen.sh
+++ b/autogen.sh
@@ -27,8 +27,8 @@ if ! [ -x "$(command -v round)" ]; then
   exit 1
 fi
 
-if ! [ -x "$(command -v inkscape)" ]; then
-  echo 'inkscape is not installed'
+if ! [ -x "$(command -v rsvg-convert)" ]; then
+  echo 'rsvg-convert is not installed (it ships with librsvg)'
   exit 1
 fi
 
@@ -46,7 +46,7 @@ fi
 for pvd in "${providers[@]}"; do
   # convert the svg to png for azure provider
   if [ "$pvd" = "onprem" ] || [ "$pvd" = "azure" ]; then
-    echo "converting the svg to png using inkscape for provider '$pvd'"
+    echo "converting the svg to png using rsvg-convert for provider '$pvd'"
     python -m scripts.resource svg2png "$pvd"
   fi
   if [ "$pvd" == "oci" ] || [ "$pvd" = "ibm" ]; then

--- a/config.py
+++ b/config.py
@@ -38,8 +38,10 @@ PROVIDERS = (
 
 CMD_ROUND = "round"
 CMD_ROUND_OPTS = ("-w",)
-CMD_SVG2PNG = "inkscape"
-CMD_SVG2PNG_OPTS = ("-w", "256", "-h", "256", "--export-type", "png")
+# Both -w and -h are given without --keep-aspect-ratio, so every icon comes out
+# exactly 256x256 no matter what the source SVG declares.
+CMD_SVG2PNG = "rsvg-convert"
+CMD_SVG2PNG_OPTS = ("-w", "256", "-h", "256")
 CMD_SVG2PNG_IM = "convert"
 CMD_SVG2PNG_IM_OPTS = ("-shave", "25%x25%", "-resize", "256x256!")
 

--- a/diagram-148bce0
+++ b/diagram-148bce0
@@ -1,0 +1,7 @@
+digraph "diagram-148bce0" {
+	graph [fontcolor="#2D3436" fontname="Sans-Serif" fontsize=15 label="diagram-148bce0" nodesep=0.70 pad=2.0 rankdir=LR ranksep=0.90 splines=spline]
+	node [fixedsize=true fontcolor="#2D3436" fontname="Sans-Serif" fontsize=13 height=1.4 imagepos=tc imagescale=true labelloc=b shape=box style=rounded width=1.4]
+	edge [arrowsize=0.8 color="#495057"]
+	"78a0f08af7ef40739cbd2412808a99db" [label=<<font point-size="12"><b>person</b></font><br/><font point-size="9">[External Person]<br/></font>> fillcolor=gray60 fixedsize=true fontcolor=white height=1 labelloc=c shape=rect style="rounded,filled" width=2]
+	"014123c46da848ae8f700dfaeeeaed28" [label=<<font point-size="12"><b>external</b></font><br/><font point-size="9">[External System]<br/></font>> fillcolor=gray60 fixedsize=true fontcolor=white height=1 labelloc=c shape=rect style=filled width=2]
+}

--- a/diagram-41afb8d
+++ b/diagram-41afb8d
@@ -1,0 +1,9 @@
+digraph "diagram-41afb8d" {
+	graph [fontcolor="#2D3436" fontname="Sans-Serif" fontsize=15 label="diagram-41afb8d" nodesep=0.70 pad=2.0 rankdir=LR ranksep=0.90 splines=spline]
+	node [fixedsize=true fontcolor="#2D3436" fontname="Sans-Serif" fontsize=13 height=1.4 imagepos=tc imagescale=true labelloc=b shape=box style=rounded width=1.4]
+	edge [arrowsize=0.8 color="#495057"]
+	"3c58e1471ef6411ebaf38d367a8d259f" [label=<<font point-size="12"><b>container1</b></font><br/><font point-size="9">[Container]<br/></font>> fillcolor=dodgerblue3 fixedsize=true fontcolor=white height=1 labelloc=c shape=rect style=filled width=2]
+	"2cefb5aa2e8149bea9c8c4dc7994d46b" [label=<<font point-size="12"><b>container2</b></font><br/><font point-size="9">[Container]<br/></font>> fillcolor=dodgerblue3 fixedsize=true fontcolor=white height=1 labelloc=c shape=rect style=filled width=2]
+	"3c58e1471ef6411ebaf38d367a8d259f" -> "2cefb5aa2e8149bea9c8c4dc7994d46b" [label=<<font point-size="10">depends on</font>> color=gray60 dir=forward fontcolor="#2D3436" fontname="Sans-Serif" fontsize=13 style=dashed]
+	"3c58e1471ef6411ebaf38d367a8d259f" -> "2cefb5aa2e8149bea9c8c4dc7994d46b" [label=<<font point-size="10">is depended on by</font>> color=gray60 dir=back fontcolor="#2D3436" fontname="Sans-Serif" fontsize=13 style=dashed]
+}

--- a/diagram-af8fef5
+++ b/diagram-af8fef5
@@ -1,0 +1,8 @@
+digraph "diagram-af8fef5" {
+	graph [fontcolor="#2D3436" fontname="Sans-Serif" fontsize=15 label="diagram-af8fef5" nodesep=0.70 pad=2.0 rankdir=LR ranksep=0.90 splines=spline]
+	node [fixedsize=true fontcolor="#2D3436" fontname="Sans-Serif" fontsize=13 height=1.4 imagepos=tc imagescale=true labelloc=b shape=box style=rounded width=1.4]
+	edge [arrowsize=0.8 color="#495057"]
+	"84ed3e0f206d495b86d309617b510c35" [label=<<font point-size="12"><b>system 1</b></font><br/><font point-size="9">[System]<br/></font>> fillcolor=dodgerblue4 fixedsize=true fontcolor=white height=1 labelloc=c shape=rect style=filled width=2]
+	"4d45c7c34b4d4b2ca0d8612edbc370a9" [label=<<font point-size="12"><b>system 2</b></font><br/><font point-size="9">[System]<br/></font>> fillcolor=dodgerblue4 fixedsize=true fontcolor=white height=1 labelloc=c shape=rect style=filled width=2]
+	"84ed3e0f206d495b86d309617b510c35" -> "4d45c7c34b4d4b2ca0d8612edbc370a9" [color=gray60 constraint=False dir=forward fontcolor="#2D3436" fontname="Sans-Serif" fontsize=13 style=dashed]
+}

--- a/diagram-bbc0d60
+++ b/diagram-bbc0d60
@@ -1,0 +1,8 @@
+digraph "diagram-bbc0d60" {
+	graph [fontcolor="#2D3436" fontname="Sans-Serif" fontsize=15 label="diagram-bbc0d60" nodesep=0.70 pad=2.0 rankdir=LR ranksep=0.90 splines=spline]
+	node [fixedsize=true fontcolor="#2D3436" fontname="Sans-Serif" fontsize=13 height=1.4 imagepos=tc imagescale=true labelloc=b shape=box style=rounded width=1.4]
+	edge [arrowsize=0.8 color="#495057"]
+	"222c43da7c214ee682504f8b4d200a4c" [label=<<font point-size="12"><b>person</b></font><br/><font point-size="9">[Person]<br/></font><br/><font point-size="10">A person.<br/><br/></font>> fillcolor=dodgerblue4 fixedsize=true fontcolor=white height=1.6 labelloc=c shape=rect style="rounded,filled" width=2.6]
+	"9a9be51209cf49c1b4a9733b8d73ed12" [label=<<font point-size="12"><b>container</b></font><br/><font point-size="9">[Container: Java application]<br/></font><br/><font point-size="10">The application.<br/><br/></font>> fillcolor=dodgerblue3 fixedsize=true fontcolor=white height=1.6 labelloc=c shape=rect style=filled width=2.6]
+	"671efd01cb324573a3e3345a41d16228" [label=<<font point-size="12"><b>database</b></font><br/><font point-size="9">[Database: Oracle database]<br/></font><br/><font point-size="10">Stores information.<br/><br/></font>> fillcolor=dodgerblue3 fixedsize=true fontcolor=white height=1.6 labelloc=b shape=cylinder style=filled width=2.6]
+}

--- a/diagram-bfd2e9a
+++ b/diagram-bfd2e9a
@@ -1,0 +1,8 @@
+digraph "diagram-bfd2e9a" {
+	graph [fontcolor="#2D3436" fontname="Sans-Serif" fontsize=15 label="diagram-bfd2e9a" nodesep=0.70 pad=2.0 rankdir=LR ranksep=0.90 splines=spline]
+	node [fixedsize=true fontcolor="#2D3436" fontname="Sans-Serif" fontsize=13 height=1.4 imagepos=tc imagescale=true labelloc=b shape=box style=rounded width=1.4]
+	edge [arrowsize=0.8 color="#495057"]
+	cb4bb0a70b684663a584ef16ed5c86de [label=<<font point-size="12"><b>container1</b></font><br/><font point-size="9">[Container]<br/></font>> fillcolor=dodgerblue3 fixedsize=true fontcolor=white height=1 labelloc=c shape=rect style=filled width=2]
+	"428291d5765342429ced394f65fbb463" [label=<<font point-size="12"><b>container2</b></font><br/><font point-size="9">[Container]<br/></font>> fillcolor=dodgerblue3 fixedsize=true fontcolor=white height=1 labelloc=c shape=rect style=filled width=2]
+	cb4bb0a70b684663a584ef16ed5c86de -> "428291d5765342429ced394f65fbb463" [dir=forward fontcolor="#2D3436" fontname="Sans-Serif" fontsize=13]
+}

--- a/diagram-c0e1f87
+++ b/diagram-c0e1f87
@@ -1,0 +1,7 @@
+digraph "diagram-c0e1f87" {
+	graph [fontcolor="#2D3436" fontname="Sans-Serif" fontsize=15 label="diagram-c0e1f87" nodesep=0.70 pad=2.0 rankdir=LR ranksep=0.90 splines=spline]
+	node [fixedsize=true fontcolor="#2D3436" fontname="Sans-Serif" fontsize=13 height=1.4 imagepos=tc imagescale=true labelloc=b shape=box style=rounded width=1.4]
+	edge [arrowsize=0.8 color="#495057"]
+	"65692efd972d4878a3ece16f8c0c2821" [label=<<font point-size="12"><b>system</b></font><br/><font point-size="9">[System]<br/></font><br/><font point-size="10">The internal system.<br/><br/></font>> fillcolor=dodgerblue4 fixedsize=true fontcolor=white height=1.6 labelloc=c shape=rect style=filled width=2.6]
+	"616f387771ae4dac9c707fcacb7f6810" [label=<<font point-size="12"><b>unknown</b></font><br/><font point-size="9">[System]<br/></font>> fillcolor=dodgerblue4 fixedsize=true fontcolor=white height=1 labelloc=c shape=rect style=filled width=2]
+}

--- a/diagram-fccf2eb
+++ b/diagram-fccf2eb
@@ -1,0 +1,9 @@
+digraph "diagram-fccf2eb" {
+	graph [fontcolor="#2D3436" fontname="Sans-Serif" fontsize=15 label="diagram-fccf2eb" nodesep=0.70 pad=2.0 rankdir=LR ranksep=0.90 splines=spline]
+	node [fixedsize=true fontcolor="#2D3436" fontname="Sans-Serif" fontsize=13 height=1.4 imagepos=tc imagescale=true labelloc=b shape=box style=rounded width=1.4]
+	edge [arrowsize=0.8 color="#495057"]
+	subgraph cluster_System {
+		graph [bgcolor=white fontname="Sans-Serif" fontsize=12 label=System labeljust=l margin=16 pencolor="#ADB5BD" rankdir=LR shape=box style=dashed]
+		"680ecb98ce7b4aa391d9b566b7bdba10" [label=<<font point-size="12"><b>container</b></font><br/><font point-size="9">[Container: type]<br/></font><br/><font point-size="10">description<br/><br/></font>> fillcolor=dodgerblue3 fixedsize=true fontcolor=white height=1.6 labelloc=c shape=rect style=filled width=2.6]
+	}
+}

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.13.3-alpine3.20
 
 # install system dependencies.
 RUN apk update && apk add --no-cache \
-  gcc libc-dev g++ graphviz git bash go imagemagick inkscape ttf-opensans curl fontconfig xdg-utils
+  gcc libc-dev g++ graphviz git bash go imagemagick rsvg-convert ttf-opensans curl fontconfig xdg-utils
 
 # install go package.
 RUN go install github.com/mingrammer/round@latest

--- a/scripts/resource.py
+++ b/scripts/resource.py
@@ -7,6 +7,7 @@ There are 2 commands available.
 """
 
 import os
+import re
 import subprocess
 import sys
 
@@ -40,6 +41,8 @@ def cleaner_azure(f):
     f = f.replace("_", "-")
     f = f.replace("(", "").replace(")", "")
     f = "-".join(f.split())
+    # The official icon pack numbers every file, e.g. 10021-icon-service-Batch-Accounts.
+    f = re.sub(r"^\d+-icon-service-", "", f, flags=re.IGNORECASE)
     for p in cfg.FILE_PREFIXES["azure"]:
         if f.startswith(p):
             f = f[len(p):]
@@ -190,12 +193,14 @@ def round_png(pvd: str) -> None:
 
 
 def svg2png(pvd: str) -> None:
-    """Convert the svg into png"""
+    """Convert the svg into png using rsvg-convert"""
 
     def _convert(base: str, path: str):
-        path = os.path.join(base, path)
-        subprocess.run([cfg.CMD_SVG2PNG, *cfg.CMD_SVG2PNG_OPTS, path])
-        subprocess.run(["rm", path])
+        path_src = os.path.join(base, path)
+        path_dest = path_src.replace(".svg", ".png")
+        # rsvg-convert writes the png to stdout unless it's given an output path.
+        subprocess.run([cfg.CMD_SVG2PNG, *cfg.CMD_SVG2PNG_OPTS, "-o", path_dest, path_src])
+        subprocess.run(["rm", path_src])
 
     for root, _, files in os.walk(resource_dir(pvd)):
         svgs = filter(lambda f: f.endswith(".svg"), files)


### PR DESCRIPTION
Fixes #1237.

Three places in the repo described how Azure SVGs become PNGs and they disagreed: `config.py` said `inkscape -w 256 -h 256`, `CONTRIBUTING.md` said `inkscape -h 256` (different output — `-h` alone keeps the source aspect ratio), and #1204 used `rsvg-convert`. Because the source SVGs are deleted after conversion, the PNG is the only artifact kept, and two rasterisers emit different bytes from identical artwork. That is how #1204 produced 632 modified icons with one genuine visual change among them.

## Decisions

**Converter: `rsvg-convert`.** It is what #1204 actually used, installs without a GUI toolchain (`brew install librsvg`, `apk add rsvg-convert`), and has a simpler CLI.

**Sizing: forced 256x256.** This preserves what `config.py` already declared. `rsvg-convert` only preserves aspect ratio when passed `--keep-aspect-ratio`, so `-w 256 -h 256` alone pins the output exactly.

## Changes

- `config.py` — converter and options, with a note on why both `-w` and `-h` are passed.
- `scripts/resource.py` — `svg2png` names an explicit destination, since `rsvg-convert` writes to stdout without `-o`. Mirrors the shape `svg2png2` already uses.
- `scripts/resource.py` — `cleaner_azure` strips the icon pack's `?????-icon-service-` prefix. This is what let the docs stop asking contributors to run their own `find`/`sed`/`rename` chain.
- `CONTRIBUTING.md` — the Azure section now covers only the directory renames that genuinely need doing by hand (spaces and `+` in names become module names), then defers to `./autogen.sh`. Both `inkscape` notes updated.
- `autogen.sh`, `DEVELOPMENT.md`, `docker/dev/Dockerfile`, `.devcontainer/Dockerfile` — dependency swapped.

## Verification

Dropped a file shaped like one straight out of the official pack into `resources/azure/`:

```
10021-icon-service-Batch Accounts (Classic).svg   (400x100 source)
```

`./autogen.sh`'s conversion and cleaning steps turned it into `batch-accounts-classic.png` at exactly 256x256, with the SVG removed — the same result as the hand-rolled chain it replaces.

Re-running the clean step over the existing ~800 Azure icons renamed nothing, so the new prefix strip is idempotent on what is already committed. No files under `resources/` are touched by this PR.

`python -m unittest tests/*.py` — 46 passed. `pre-commit run` — all hooks pass.

## Notes

This standardises the tool but does not re-render anything, so it will not by itself stop the next refresh from churning bytes in transparent regions. #1238 covers that half.