### PR TITLE
feat(playground): target search terms for the online editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Diagrams lets you draw the cloud system architecture **in Python code**. It was 
 
 ## Getting Started
 
-> Want to try it first? The [**Playground**](https://diagrams.mingrammer.com/playground/) runs **diagrams** right in your browser — no installation required.
+> Want to try it first? The [**online playground**](https://diagrams.mingrammer.com/playground/) runs **diagrams** right in your browser — no installation required.
 
 It requires **Python 3.9** or higher, check your Python version first.
 
@@ -66,7 +66,7 @@ You can start with [quick start](https://diagrams.mingrammer.com/docs/getting-st
 
 [**diagrams.mingrammer.com/playground**](https://diagrams.mingrammer.com/playground/)
 
-Write **diagrams** code and see the rendered diagram instantly, without installing anything. It runs the real **diagrams** package in your browser via [Pyodide](https://pyodide.org), and supports node search, autocompletion, PNG/SVG/JPEG export, and shareable links.
+A free online editor for **diagrams**: write Diagram as Code in Python and see the rendered architecture diagram instantly, without installing Python or Graphviz. It runs the real **diagrams** package in your browser via [Pyodide](https://pyodide.org), and supports node search, autocompletion, PNG/SVG/JPEG export, and shareable links. See the [playground guide](https://diagrams.mingrammer.com/docs/getting-started/playground) for details.
 
 ## Examples
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -3,7 +3,7 @@ id: installation
 title: Installation
 ---
 
-> Prefer to try it without installing? The [**Playground**](/playground/) runs **diagrams** in your browser.
+> Prefer to try it without installing? The [**online playground**](/playground/) runs **diagrams** in your browser — see the [playground guide](/docs/getting-started/playground).
 
 **diagrams** requires **Python 3.7** or higher, check your Python version first.
 

--- a/docs/getting-started/playground.md
+++ b/docs/getting-started/playground.md
@@ -1,0 +1,43 @@
+---
+id: playground
+title: Online Playground
+---
+
+The **Diagrams Playground** is a free online editor for the **diagrams** library. Write Diagram as Code in Python and see the rendered architecture diagram appear next to it — in your web browser, with nothing to install.
+
+> **[Open the Playground →](/playground/)**
+
+## Why use it
+
+Installing **diagrams** locally means installing Python *and* [Graphviz](https://www.graphviz.org/). The playground skips both, which makes it handy when you want to:
+
+- try **diagrams** before installing anything,
+- sketch a cloud architecture diagram from a laptop that isn't set up for Python,
+- share a working diagram with a teammate as a single link,
+- look up which node classes exist for AWS, Azure, GCP, Kubernetes and the other providers.
+
+## What it can do
+
+- **Live preview** — the diagram re-renders as you type.
+- **Node browser** — search every available node, or browse the full provider → category tree, and click to insert the matching `import`.
+- **Autocompletion** — import paths and node names complete as you type, with signature hints for `Diagram`, `Cluster` and `Edge`.
+- **Export** — download the result as PNG, SVG or JPEG at a size you choose, or copy the image straight to your clipboard.
+- **Share links** — the whole diagram is encoded into the URL, so sending the link is enough. Nothing is stored on a server.
+- **Examples** — start from a ready-made diagram instead of a blank editor.
+
+## How it works
+
+The playground runs the real **diagrams** package — not a reimplementation — inside your browser using [Pyodide](https://pyodide.org), which is CPython compiled to WebAssembly. Graph layout is done by a WebAssembly build of Graphviz.
+
+Everything executes locally in the browser tab: your code is never uploaded, and there is no backend. The first visit downloads the Python runtime, so it takes a few seconds; after that it is cached.
+
+## When to install instead
+
+The playground is for quick work and sharing. Install the library ([installation guide](/docs/getting-started/installation)) when you want to:
+
+- keep diagrams in version control next to your code,
+- generate diagrams in CI or a build script,
+- use custom local icons, or
+- work offline.
+
+The Python code is identical either way, so anything you write in the playground runs unchanged after `pip install diagrams`.

--- a/playground/index.html
+++ b/playground/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Diagrams Playground — Diagram as Code in your browser</title>
+    <title>Diagrams Playground — Online Python Diagram Editor</title>
     <meta
       name="description"
-      content="Write Python and watch cloud architecture diagrams render instantly in your browser — nothing to install. Powered by the diagrams library running on Pyodide."
+      content="Run the Python diagrams library online. Write Diagram as Code in your browser and render AWS, Azure, GCP and Kubernetes architecture diagrams — no install required."
     />
     <link rel="canonical" href="https://diagrams.mingrammer.com/playground/" />
     <!-- Real diagrams project logo; relative href survives sub-path deploys. -->
@@ -18,10 +18,10 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Diagrams" />
     <meta property="og:url" content="https://diagrams.mingrammer.com/playground/" />
-    <meta property="og:title" content="Diagrams Playground — Diagram as Code in your browser" />
+    <meta property="og:title" content="Diagrams Playground — Online Python Diagram Editor" />
     <meta
       property="og:description"
-      content="Write Python and watch cloud architecture diagrams render instantly in your browser — nothing to install."
+      content="Write Diagram as Code in your browser and render AWS, Azure, GCP and Kubernetes architecture diagrams instantly — no install required."
     />
     <meta property="og:image" content="https://diagrams.mingrammer.com/playground/og-image.png" />
     <meta property="og:image:width" content="1200" />
@@ -31,12 +31,32 @@
       content="The Diagrams Playground: Python code on the left, a rendered cloud architecture diagram on the right."
     />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Diagrams Playground — Diagram as Code in your browser" />
+    <meta name="twitter:title" content="Diagrams Playground — Online Python Diagram Editor" />
     <meta
       name="twitter:description"
-      content="Write Python and watch cloud architecture diagrams render instantly in your browser — nothing to install."
+      content="Write Diagram as Code in your browser and render AWS, Azure, GCP and Kubernetes architecture diagrams instantly — no install required."
     />
     <meta name="twitter:image" content="https://diagrams.mingrammer.com/playground/og-image.png" />
+
+    <!-- Tells search engines this page is the tool itself, not an article
+         about it. Everything here is factual: it is free and runs entirely
+         in the browser. -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "Diagrams Playground",
+        "alternateName": "Python Diagrams Online Editor",
+        "url": "https://diagrams.mingrammer.com/playground/",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Any (runs in a web browser)",
+        "browserRequirements": "Requires JavaScript and WebAssembly",
+        "description": "An online editor for the Python diagrams library. Write Diagram as Code in the browser and render AWS, Azure, GCP and Kubernetes architecture diagrams without installing anything.",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "license": "https://github.com/mingrammer/diagrams/blob/master/LICENSE",
+        "isPartOf": { "@type": "WebSite", "name": "Diagrams", "url": "https://diagrams.mingrammer.com/" }
+      }
+    </script>
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -11,6 +11,9 @@
       "getting-started/installation": {
         "title": "Installation"
       },
+      "getting-started/playground": {
+        "title": "Online Playground"
+      },
       "guides/cluster": {
         "title": "Clusters"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -2,6 +2,7 @@
   "docs": {
     "Getting Started": [
       "getting-started/installation",
+      "getting-started/playground",
       "getting-started/examples"
     ],
     "Guides": [


### PR DESCRIPTION
Follow-up to #1245. The playground had nothing for search engines to match: the title said "Diagram as Code in your browser", and the app is a tool UI with almost no prose — so queries like *python diagrams online* or *diagrams web editor* had no text to rank against.

## Changes

**Playground page**
- Title → `Diagrams Playground — Online Python Diagram Editor`
- Description rewritten around what people search for (online, Python, browser, AWS/Azure/GCP/Kubernetes, no install)
- `WebApplication` JSON-LD so Google can classify it as a free, browser-based developer tool

**New docs page — [Online Playground](https://github.com/mingrammer/diagrams/blob/feat/playground-seo-keywords/docs/getting-started/playground.md)**

Static HTML on an established domain indexes far more reliably than a JS app shell, so this page carries the real explanatory content — why you'd use it, what it does, how it works, and when to install the library instead — and links to the tool. Added to the Getting Started sidebar.

**Anchor text** — README and the installation doc now link with "online playground" instead of a bare "Playground".

## Note on expectations

*python diagrams online* and *diagrams web editor* are realistic targets. **diagrams online** is not, in the short term — diagrams.net (draw.io) effectively owns that phrase. Ranking also depends on indexing, which takes weeks; submitting the sitemap in Search Console after deploy will speed it up.

No `<meta name="keywords">` was added — Google has ignored it since 2009.

## Verification
- Docs build clean; `docs/getting-started/playground.html` generated, title `Online Playground · Diagrams`, links to `/playground/` resolve
- Playground build clean; JSON-LD parses as valid `WebApplication`
- Unit tests 109/109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
