### PR TITLE
chore(site): add Google Search Console verification tag

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -85,6 +85,22 @@ jobs:
               print("added playground to sitemap")
           else:
               print("playground already in sitemap")
+
+          # Google Search Console ownership check. Docusaurus 1.x has no
+          # config hook for arbitrary <head> tags, and the verifier reads the
+          # served HTML without running JS, so the tag is injected into the
+          # built homepage here.
+          verification = (
+              '<meta name="google-site-verification" '
+              'content="p1XvVxyPOUJ6LYX5rAqSAM27tW2AFMaacg1BTr8mfR4" />'
+          )
+          home = Path("_site/index.html")
+          html = home.read_text()
+          if "google-site-verification" not in html:
+              home.write_text(html.replace("<head>", "<head>" + verification, 1))
+              print("added Search Console verification to homepage")
+          else:
+              print("verification tag already present")
           PY
 
       - name: Deploy to gh-pages

--- a/playground/index.html
+++ b/playground/index.html
@@ -9,6 +9,9 @@
       content="Run the Python diagrams library online. Write Diagram as Code in your browser and render AWS, Azure, GCP and Kubernetes architecture diagrams — no install required."
     />
     <link rel="canonical" href="https://diagrams.mingrammer.com/playground/" />
+    <!-- Search Console ownership, in case /playground/ is registered as its
+         own URL-prefix property (the site root gets the same tag at deploy). -->
+    <meta name="google-site-verification" content="p1XvVxyPOUJ6LYX5rAqSAM27tW2AFMaacg1BTr8mfR4" />
     <!-- Real diagrams project logo; relative href survives sub-path deploys. -->
     <link rel="icon" type="image/png" href="diagrams-logo.png" />
 


### PR DESCRIPTION
Adds the Google Search Console ownership tag so the sitemap can be submitted and indexing monitored.

## Where it goes

**Site root** (`diagrams.mingrammer.com/`) — injected during the deploy `Assemble site` step.

Docusaurus 1.x has no config option for arbitrary `<head>` tags (`Head.js` only consumes `scripts`/`stylesheets`), and Search Console reads the served HTML **without executing JavaScript**, so a script-based injection wouldn't verify. Injecting into the built `index.html` puts it in static HTML and re-applies on every deploy. The step is idempotent.

**Playground** (`/playground/`) — added directly to its `index.html`, in case it's registered as its own URL-prefix property.

## Verification

Ran the real docs build and the injection against its output:

```
<head><meta name="google-site-verification" content="p1XvV…" /><meta charSet="utf-8"/>…
```

- Tag lands immediately inside `<head>`, exactly once
- Playground build carries the tag in `dist/index.html`
- Workflow YAML parses; unit tests 109/109

## After merge

Deploy runs, then hit **Verify** in Search Console. Worth submitting `https://diagrams.mingrammer.com/sitemap.xml` at the same time — it now includes `/playground/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
