### PR TITLE
fix: move dev dependencies to hatch env to stop pre-commit leaking into runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,13 @@ diagrams = "diagrams.cli:main"
 Homepage = "https://diagrams.mingrammer.com"
 Repository = "https://github.com/mingrammer/diagrams"
 
-[tool.poetry.group.dev.dependencies]
-pytest = "^8.3"
-pylint = "^3.3"
-rope = "^1.13"
-isort = "^6.0"
-black = "^24.4"
-pre-commit = "^4.0"
+[tool.hatch.envs.dev.dependencies]
+pytest = ">=8.3,<9"
+pylint = ">=3.3,<4"
+rope = ">=1.13,<2"
+isort = ">=6.0,<7"
+black = ">=24.4,<25"
+pre-commit = ">=4.0,<5"
 
 [tool.hatch.build]
 only-include = ["diagrams", "resources"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,15 @@ diagrams = "diagrams.cli:main"
 Homepage = "https://diagrams.mingrammer.com"
 Repository = "https://github.com/mingrammer/diagrams"
 
-[tool.hatch.envs.dev.dependencies]
-pytest = ">=8.3,<9"
-pylint = ">=3.3,<4"
-rope = ">=1.13,<2"
-isort = ">=6.0,<7"
-black = ">=24.4,<25"
-pre-commit = ">=4.0,<5"
+[tool.hatch.envs.dev]
+dependencies = [
+    "pytest>=8.3,<9",
+    "pylint>=3.3,<4",
+    "rope>=1.13,<2",
+    "isort>=6.0,<7",
+    "black>=24.4,<25",
+    "pre-commit>=4.0,<5",
+]
 
 [tool.hatch.build]
 only-include = ["diagrams", "resources"]


### PR DESCRIPTION
### Problem

Since v0.24.2, `pre-commit` (and its transitive dependencies) has been showing up as a runtime dependency for all users of the library:

```
$ pip show diagrams
Requires: graphviz, jinja2, pre-commit
```

The root cause is that dev dependencies were declared under `[tool.poetry.group.dev.dependencies]`, which is a Poetry-specific namespace. Some pip/build-tool versions treat this as extra or optional metadata included in the wheel, causing `pre-commit>=4.0.1` to appear in `requires_dist` on PyPI even though it is purely a development tool.

### Fix

Replace `[tool.poetry.group.dev.dependencies]` with `[tool.hatch.envs.dev]` + `dependencies = [...]`, which is the native hatchling way to declare development-only dependencies. Entries declared this way are never included in the wheel's `requires_dist`, so `pre-commit` will no longer be installed as a transitive dependency for end users.

### Testing

After this change, building the wheel and inspecting its metadata:

```bash
pip install hatchling
python -m hatchling build
unzip -p dist/diagrams-*.whl diagrams-*/METADATA | grep Requires-Dist
# Only shows: graphviz, jinja2 — no pre-commit
```

Fixes #1193